### PR TITLE
リマインドをOFFにしてもセッションが更新されるよう修正

### DIFF
--- a/lib/pomoru/session/reminder.rb
+++ b/lib/pomoru/session/reminder.rb
@@ -27,7 +27,7 @@ class Reminder
     if session.timer.end != @end && @end > Time.now
       remind_remaining = @end.to_i - Time.now.to_i
       sleep remind_remaining
-      return false unless latest_reminder?(session, time_executed, reminder_end)
+      return false unless latest_reminder?(session, time_executed, reminder_end) && session.reminder.running
 
       session.event.send_message("#{(session.timer.end.to_i - Time.now.to_i) / 60} minute left until end of #{session.state}!")
       # session.event.voice.play_file()
@@ -58,6 +58,6 @@ class Reminder
 
   def latest_reminder?(session, time_executed, reminder_end)
     session = SessionManager::ACTIVE_SESSIONS[SessionManager.session_id_from(session.event)]
-    session&.timer&.running && reminder_end == session.reminder.end && time_executed == session.reminder.time_executed && session.reminder.running
+    session&.timer&.running && reminder_end == session.reminder.end && time_executed == session.reminder.time_executed
   end
 end


### PR DESCRIPTION
## やったこと
リマインドをONにしたセッションの通知後にOFFにすると次のセッションが更新されないバグを修正しました。

## 内容

1. `pmt!start 2 2`を実行しポモドーロタイマーをスタート
2. その後に`pmt!remind 1 1`を実行してリマインダーアラートの設定をONにする
3. 通知が1分前にくる（下のキャプチャの1番上を参考）

![スクリーンショット 2022-03-22 16 31 44](https://user-images.githubusercontent.com/74460623/159429882-a585fe5b-c64f-4558-9112-8d757690df9d.png)

4. `pmt!remind_off`でリマインドをOFFにする
5. 本来だと次のセッションの通知がくるはずだがこない
6. `pmt!status`で残り時間を確認してみたところ数字が-になっていることに気づく

## 問題だったこと
リマインド通知後とセッション終了後に挟んでいた分岐処理で`remind.running`がfalseになっているとそのスレッドがreturnされてしまっていることが原因でした。

セッション終了後時点でリマインドがOFFになっていても次のセッションが更新されるように分岐処理を修正することで対応。