### PR TITLE
リファクタリング#2

### DIFF
--- a/lib/pomoru/commands/control.rb
+++ b/lib/pomoru/commands/control.rb
@@ -2,7 +2,6 @@
 
 require 'discordrb'
 require 'dotenv/load'
-require_relative '../config/config'
 require_relative '../config/user_messages'
 require_relative '../session/countdown'
 require_relative '../session/session'
@@ -28,7 +27,7 @@ module Bot::Commands
         return
       end
       if Settings.invalid?(pomodoro, short_break, long_break, intervals)
-        event.send_message("1〜#{MAX_INTERVAL_MINUTES}分までのパラメータを入力してください")
+        event.send_message(NUM_OUTSIDE_ONE_AND_MAX_INTERVAL_ERR)
         return
       end
 
@@ -133,7 +132,7 @@ module Bot::Commands
           return
         end
         if Settings.invalid?(pomodoro, short_break, long_break, intervals)
-          event.send_message("1〜#{MAX_INTERVAL_MINUTES}分までのパラメータを入力してください")
+          event.send_message(NUM_OUTSIDE_ONE_AND_MAX_INTERVAL_ERR)
           return
         end
         SessionController.edit(session, Settings.new(

--- a/lib/pomoru/commands/control.rb
+++ b/lib/pomoru/commands/control.rb
@@ -49,6 +49,7 @@ module Bot::Commands
     command :pause do |event|
       session = SessionManager.get_session(event)
       return if Countdown.running?(session)
+
       if session
         timer = session.timer
         unless timer.running
@@ -65,6 +66,7 @@ module Bot::Commands
     command :resume do |event|
       session = SessionManager.get_session(event)
       return if Countdown.running?(session)
+
       if session
         timer = session.timer
         if session.timer.running
@@ -82,6 +84,7 @@ module Bot::Commands
     command :restart do |event|
       session = SessionManager.get_session(event)
       return if Countdown.running?(session)
+
       if session
         session.timer.time_remaining_update(session)
         event.send_message("#{session.state}をリスタートしました")
@@ -92,6 +95,7 @@ module Bot::Commands
     command :skip do |event|
       session = SessionManager.get_session(event)
       return if Countdown.running?(session)
+
       if session
         stats = session.stats
         if stats.pomos_completed >= 0 && session.state == State::POMODORO
@@ -122,6 +126,7 @@ module Bot::Commands
     command :edit do |event, pomodoro = nil, short_break = nil, long_break = nil, intervals = nil|
       session = SessionManager.get_session(event)
       return if Countdown.running?(session)
+
       if session
         if pomodoro.nil?
           event.send_message(MISSING_ARG_ERR)

--- a/lib/pomoru/commands/control.rb
+++ b/lib/pomoru/commands/control.rb
@@ -4,6 +4,7 @@ require 'discordrb'
 require 'dotenv/load'
 require_relative '../config/config'
 require_relative '../config/user_messages'
+require_relative '../session/countdown'
 require_relative '../session/session'
 require_relative '../session/session_controller'
 require_relative '../session/session_manager'
@@ -47,10 +48,7 @@ module Bot::Commands
 
     command :pause do |event|
       session = SessionManager.get_session(event)
-      if session.state == State::COUNTDOWN
-        session.event.send_message(COUNTDOWN_RUNNING)
-        return
-      end
+      return if Countdown.running?(session)
       if session
         timer = session.timer
         unless timer.running
@@ -66,10 +64,7 @@ module Bot::Commands
 
     command :resume do |event|
       session = SessionManager.get_session(event)
-      if session.state == State::COUNTDOWN
-        session.event.send_message(COUNTDOWN_RUNNING)
-        return
-      end
+      return if Countdown.running?(session)
       if session
         timer = session.timer
         if session.timer.running
@@ -86,10 +81,7 @@ module Bot::Commands
 
     command :restart do |event|
       session = SessionManager.get_session(event)
-      if session.state == State::COUNTDOWN
-        session.event.send_message(COUNTDOWN_RUNNING)
-        return
-      end
+      return if Countdown.running?(session)
       if session
         session.timer.time_remaining_update(session)
         event.send_message("#{session.state}をリスタートしました")
@@ -99,10 +91,7 @@ module Bot::Commands
 
     command :skip do |event|
       session = SessionManager.get_session(event)
-      if session.state == State::COUNTDOWN
-        session.event.send_message(COUNTDOWN_RUNNING)
-        return
-      end
+      return if Countdown.running?(session)
       if session
         stats = session.stats
         if stats.pomos_completed >= 0 && session.state == State::POMODORO
@@ -132,10 +121,7 @@ module Bot::Commands
 
     command :edit do |event, pomodoro = nil, short_break = nil, long_break = nil, intervals = nil|
       session = SessionManager.get_session(event)
-      if session.state == State::COUNTDOWN
-        session.event.send_message(COUNTDOWN_RUNNING)
-        return
-      end
+      return if Countdown.running?(session)
       if session
         if pomodoro.nil?
           event.send_message(MISSING_ARG_ERR)

--- a/lib/pomoru/commands/info.rb
+++ b/lib/pomoru/commands/info.rb
@@ -22,6 +22,7 @@ module Bot::Commands
     command :status do |event|
       session = SessionManager.get_session(event)
       return if Countdown.running?(session)
+
       if session
         session.message.edit('', MessageBuilder.status_embed(session, colour: 0xff0000))
         session.message.unpin
@@ -35,6 +36,7 @@ module Bot::Commands
     command :stats do |event|
       session = SessionManager.get_session(event)
       return if Countdown.running?(session)
+
       if session
         stats = session.stats
         if stats.pomos_completed.positive?
@@ -48,6 +50,7 @@ module Bot::Commands
     command :settings do |event|
       session = SessionManager.get_session(event)
       return if Countdown.running?(session)
+
       event.send_embed('', MessageBuilder.settings_embed(session)) if session
       event.send_embed('', MessageBuilder.reminders_embed(session)) if session.reminder.running
     end

--- a/lib/pomoru/commands/info.rb
+++ b/lib/pomoru/commands/info.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'discordrb'
+require_relative '../session/countdown'
 require_relative '../session/session_manager'
 require_relative '../message_builder'
 require_relative '../state'
@@ -20,10 +21,7 @@ module Bot::Commands
 
     command :status do |event|
       session = SessionManager.get_session(event)
-      if session.state == State::COUNTDOWN
-        session.event.send_message(COUNTDOWN_RUNNING)
-        return
-      end
+      return if Countdown.running?(session)
       if session
         session.message.edit('', MessageBuilder.status_embed(session, colour: 0xff0000))
         session.message.unpin
@@ -36,10 +34,7 @@ module Bot::Commands
 
     command :stats do |event|
       session = SessionManager.get_session(event)
-      if session.state == State::COUNTDOWN
-        session.event.send_message(COUNTDOWN_RUNNING)
-        return
-      end
+      return if Countdown.running?(session)
       if session
         stats = session.stats
         if stats.pomos_completed.positive?
@@ -52,10 +47,7 @@ module Bot::Commands
 
     command :settings do |event|
       session = SessionManager.get_session(event)
-      if session.state == State::COUNTDOWN
-        session.event.send_message(COUNTDOWN_RUNNING)
-        return
-      end
+      return if Countdown.running?(session)
       event.send_embed('', MessageBuilder.settings_embed(session)) if session
       event.send_embed('', MessageBuilder.reminders_embed(session)) if session.reminder.running
     end

--- a/lib/pomoru/commands/other.rb
+++ b/lib/pomoru/commands/other.rb
@@ -43,10 +43,7 @@ module Bot::Commands
 
     command :remind do |event, pomodoro, short_break, long_break|
       session = SessionManager.get_session(event)
-      if session.state == State::COUNTDOWN
-        session.event.send_message(COUNTDOWN_RUNNING)
-        return
-      end
+      return if Countdown.running?(session)
       if session
         if pomodoro.nil? && session.reminder.running
           SessionMessenger.send_remind_msg(session)
@@ -57,9 +54,9 @@ module Bot::Commands
                                               short_break,
                                               long_break
                                             ))
-          SessionMessenger.send_remind_msg(session)
           session.reminder.running = true
           session.message.edit('', MessageBuilder.status_embed(session))
+          SessionMessenger.send_remind_msg(session)
           SessionController.resume(session)
         end
       end
@@ -67,10 +64,7 @@ module Bot::Commands
 
     command :remind_off do |event|
       session = SessionManager.get_session(event)
-      if session.state == State::COUNTDOWN
-        session.event.send_message(COUNTDOWN_RUNNING)
-        return
-      end
+      return if Countdown.running?(session)
       if session
         reminder = session.reminder
         unless reminder.running
@@ -85,10 +79,7 @@ module Bot::Commands
 
     command :volume do |event, volume = nil|
       session = SessionManager.get_session(event)
-      if session.state == State::COUNTDOWN
-        session.event.send_message(COUNTDOWN_RUNNING)
-        return
-      end
+      return if Countdown.running?(session)
       if session
         if volume.nil?
           event.send_message("今の音量は#{event.voice.filter_volume}/2です")

--- a/lib/pomoru/commands/other.rb
+++ b/lib/pomoru/commands/other.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'discordrb'
-require_relative '../config/config'
 require_relative '../config/user_messages'
 require_relative '../session/countdown'
 require_relative '../session/reminder'
@@ -27,7 +26,7 @@ module Bot::Commands
         event.send_message(MISSING_ARG_ERR)
         return
       elsif Settings.invalid?(duration)
-        event.send_message("1〜#{MAX_INTERVAL_MINUTES}分までのパラメータを入力してください")
+        event.send_message(NUM_OUTSIDE_ONE_AND_MAX_INTERVAL_ERR)
         return
       end
 

--- a/lib/pomoru/commands/other.rb
+++ b/lib/pomoru/commands/other.rb
@@ -44,6 +44,7 @@ module Bot::Commands
     command :remind do |event, pomodoro, short_break, long_break|
       session = SessionManager.get_session(event)
       return if Countdown.running?(session)
+
       if session
         if pomodoro.nil? && session.reminder.running
           SessionMessenger.send_remind_msg(session)
@@ -65,6 +66,7 @@ module Bot::Commands
     command :remind_off do |event|
       session = SessionManager.get_session(event)
       return if Countdown.running?(session)
+
       if session
         reminder = session.reminder
         unless reminder.running
@@ -80,6 +82,7 @@ module Bot::Commands
     command :volume do |event, volume = nil|
       session = SessionManager.get_session(event)
       return if Countdown.running?(session)
+
       if session
         if volume.nil?
           event.send_message("今の音量は#{event.voice.filter_volume}/2です")

--- a/lib/pomoru/commands/subscribe.rb
+++ b/lib/pomoru/commands/subscribe.rb
@@ -14,6 +14,7 @@ module Bot::Commands
     command :autoshush do |event, who = ''|
       session = SessionManager.get_session(event)
       return if Countdown.running?(session)
+
       if session
         if event.user.voice_channel.nil?
           event.send_message("ボイスチャンネルに参加して#{ENV['PREFIX']}#{event.command.name}を実行してください")

--- a/lib/pomoru/commands/subscribe.rb
+++ b/lib/pomoru/commands/subscribe.rb
@@ -4,6 +4,7 @@ require 'discordrb'
 require 'dotenv/load'
 require_relative '../config/user_messages'
 require_relative '../session/autoshush'
+require_relative '../session/countdown'
 require_relative '../session/session_manager'
 
 module Bot::Commands
@@ -12,6 +13,7 @@ module Bot::Commands
 
     command :autoshush do |event, who = ''|
       session = SessionManager.get_session(event)
+      return if Countdown.running?(session)
       if session
         if event.user.voice_channel.nil?
           event.send_message("ボイスチャンネルに参加して#{ENV['PREFIX']}#{event.command.name}を実行してください")

--- a/lib/pomoru/config/user_messages.rb
+++ b/lib/pomoru/config/user_messages.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../config/config'
+
 GREETINGS = [
   'こんにちは！今日も集中できるといいですね',
   '集中する時間を決めてみんなでワイワイ作業しましょう！',
@@ -14,4 +16,5 @@ GREETINGS = [
 MISSING_ARG_ERR = '最低でも1つパラメータを入力する必要があります'
 AUTOSHUSH_ARG_ERR = '"me"もしくは"all"を入力してください'
 ACTIVE_SESSION_EXISTS_ERR = '既にアクティブなセッションがあります'
+NUM_OUTSIDE_ONE_AND_MAX_INTERVAL_ERR = "1〜#{MAX_INTERVAL_MINUTES}分までのパラメータを入力してください".freeze
 COUNTDOWN_RUNNING = 'カウントダウンタイマーが動いています'

--- a/lib/pomoru/message_builder.rb
+++ b/lib/pomoru/message_builder.rb
@@ -10,20 +10,23 @@ class MessageBuilder
       status = session.timer.running ? 'Running' : 'Pausing'
       reminder = session.reminder.running ? 'On' : 'Off'
       autoshush = session.autoshush.all ? 'On' : 'Off'
-      status_str = "Current intervals: #{state}\n \
-        Status: #{status}\n \
-        Reminder alerts: #{reminder}\n \
-        Autoshush: #{autoshush}"
-
+      status_str = <<~TEXT
+        Current intervals: #{state}
+        Status: #{status}
+        Reminder alerts: #{reminder}
+        Autoshush: #{autoshush}
+      TEXT
       create_embed('Timer', status_str, colour)
     end
 
     def settings_embed(session)
       settings = session.settings
-      settings_str = "Pomodoro: #{settings.pomodoro} min\n \
-        Short break: #{settings.short_break} min\n \
-        Long break: #{settings.long_break} min\n \
-        Interbals: #{settings.intervals}"
+      settings_str = <<~TEXT
+        Pomodoro: #{settings.pomodoro} min
+        Short break: #{settings.short_break} min
+        Long break: #{settings.long_break} min
+        Interbals: #{settings.intervals}
+      TEXT
       colour = 0xFF8000
 
       create_embed('Session settings', settings_str, colour)
@@ -73,9 +76,11 @@ class MessageBuilder
       pomo_txt = molding_reminder_txt(reminders.pomodoro)
       short_txt = molding_reminder_txt(reminders.short_break)
       long_txt = molding_reminder_txt(reminders.long_break)
-      reminders_str = "Pomodoro: #{pomo_txt}\n \
-        Short break: #{short_txt}\n \
-        Long break: #{long_txt}"
+      reminders_str = <<~TEXT
+        Pomodoro: #{pomo_txt}
+        Short break: #{short_txt}
+        Long break: #{long_txt}
+      TEXT
       colour = 0xFEE75C
 
       create_embed('Reminder alerts', reminders_str, colour)

--- a/lib/pomoru/session/countdown.rb
+++ b/lib/pomoru/session/countdown.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 require 'discordrb'
+require_relative '../config/user_messages'
 require_relative './session_controller'
 require_relative './session_manager'
 require_relative '../message_builder'
+require_relative '../state'
 
 class Countdown
   class << self
@@ -22,6 +24,15 @@ class Countdown
       session.message.edit('', embed)
       SessionController.end(session)
     end
+
+    def running?(session)
+      if session.state == State::COUNTDOWN
+        session.event.send_message(COUNTDOWN_RUNNING)
+        return true
+      end
+    end
+
+    private
 
     def latest_session?(session, timer_remaining)
       session = SessionManager::ACTIVE_SESSIONS[SessionManager.session_id_from(session.event)]

--- a/lib/pomoru/session/countdown.rb
+++ b/lib/pomoru/session/countdown.rb
@@ -26,10 +26,10 @@ class Countdown
     end
 
     def running?(session)
-      if session.state == State::COUNTDOWN
-        session.event.send_message(COUNTDOWN_RUNNING)
-        return true
-      end
+      return unless session.state == State::COUNTDOWN
+
+      session.event.send_message(COUNTDOWN_RUNNING)
+      true
     end
 
     private

--- a/lib/pomoru/session/session_controller.rb
+++ b/lib/pomoru/session/session_controller.rb
@@ -43,7 +43,7 @@ class SessionController
       intervals = new_settings.intervals || session.settings.intervals
       session.settings = Settings.new(new_settings.pomodoro, short_break, long_break, intervals)
       if session.reminder.running
-        Reminder.automatically_update_reminders(session, new_settings.pomodoro, short_break, long_break, intervals)
+        Reminder.automatically_update(session, new_settings.pomodoro, short_break, long_break, intervals)
         session.reminder.running = true
       end
       session.settings
@@ -53,7 +53,7 @@ class SessionController
       pomodoro_reminder = new_reminder.pomodoro || session.reminder.pomodoro
       short_break_reminder = new_reminder.short_break || session.reminder.short_break
       long_break_reminder = new_reminder.long_break || session.reminder.long_break
-      Reminder.automatically_update_reminders(session, pomodoro_reminder.to_i, short_break_reminder.to_i, long_break_reminder.to_i)
+      Reminder.automatically_update(session, pomodoro_reminder.to_i, short_break_reminder.to_i, long_break_reminder.to_i)
     end
 
     private

--- a/lib/pomoru/session/session_messenger.rb
+++ b/lib/pomoru/session/session_messenger.rb
@@ -26,6 +26,8 @@ class SessionMessenger
     def send_remind_msg(session)
       reminders = session.reminder
       if reminders.pomodoro == 'None' && reminders.short_break == 'None' && reminders.long_break == 'None'
+        session.reminder.running = false
+        session.message.edit('', MessageBuilder.status_embed(session))
         session.event.send_message('すべてのリマインダーは0です')
       else
         session.event.send_embed('リマインダーアラートがOnになりました', MessageBuilder.reminders_embed(session))

--- a/lib/pomoru/voice/voice_manager.rb
+++ b/lib/pomoru/voice/voice_manager.rb
@@ -2,6 +2,7 @@
 
 require 'dotenv/load'
 require_relative '../config/user_messages'
+require_relative './voice_accessor'
 
 class VoiceManager
   # rubocop:disable Style/MutableConstant
@@ -19,12 +20,14 @@ class VoiceManager
       end
       voice_client = event.bot.voice_connect(event.user.voice_channel)
       event.bot.member(event.server.id, CLIENT_ID).server_deafen
+      event.bot.game = VoiceAccessor.get_voice_channel(session).name.to_s
       CONNECTED_SESSIONS[voice_channel_id_from(event)] = session if voice_client
       true
     end
 
     def disconnect(session)
       CONNECTED_SESSIONS.delete(voice_channel_id_from(session.event))
+      session.event.bot.update_status('online', nil, nil)
       session.event.bot.voice_destroy(session.event.server.id)
     end
 

--- a/lib/pomoru/voice/voice_player.rb
+++ b/lib/pomoru/voice/voice_player.rb
@@ -5,21 +5,23 @@ require_relative '../state'
 class VoicePlayer
   POMO_START = "#{Dir.pwd}/sounds/pomodoro_start.mp3".freeze
   POMO_END = "#{Dir.pwd}/sounds/pomodoro_end.mp3".freeze
-  REMIND_START = "#{Dir.pwd}/sounds/remind_start.mp3".freeze
+  REMIND_ALERT = "#{Dir.pwd}/sounds/remind_start.mp3".freeze
 
   class << self
     def alert(session, value = nil)
       return unless session.event.voice
 
-      if value.nil? || (session.state == State::SHORT_BREAK || session.state == State::LONG_BREAK)
-        path = POMO_START # timer start and pomodoro
-      elsif value == session.timer.end
+      if value.nil? || (value == session.timer.end && !(session.state == State::POMODORO))
+        path = POMO_START # start and pomodoro
+      elsif value == session.timer.end && session.state == State::POMODORO
         path = POMO_END # short break and long break
       elsif value == session.reminder.end
-        path = REMIND_START # remind
+        path = REMIND_ALERT # remind
       end
       init_alert_thread(session, path)
     end
+
+    private
 
     def init_alert_thread(session, path)
       Thread.new { session.event.voice.play_file(path) }

--- a/lib/pomoru/voice/voice_player.rb
+++ b/lib/pomoru/voice/voice_player.rb
@@ -9,9 +9,7 @@ class VoicePlayer
 
   class << self
     def alert(session, value = nil)
-      return unless session.event.voice
-
-      if value.nil? || (value == session.timer.end && !(session.state == State::POMODORO))
+      if value.nil? || (value == session.timer.end && session.state != State::POMODORO)
         path = POMO_START # start and pomodoro
       elsif value == session.timer.end && session.state == State::POMODORO
         path = POMO_END # short break and long break

--- a/lib/pomoru/voice/voice_player.rb
+++ b/lib/pomoru/voice/voice_player.rb
@@ -5,7 +5,7 @@ require_relative '../state'
 class VoicePlayer
   POMO_START = "#{Dir.pwd}/sounds/pomodoro_start.mp3".freeze
   POMO_END = "#{Dir.pwd}/sounds/pomodoro_end.mp3".freeze
-  REMIND_ALERT = "#{Dir.pwd}/sounds/remind_start.mp3".freeze
+  REMIND_ALERT = "#{Dir.pwd}/sounds/remind_alert.mp3".freeze
 
   class << self
     def alert(session, value = nil)

--- a/test/message_builder_test.rb
+++ b/test/message_builder_test.rb
@@ -27,10 +27,12 @@ class MessageBuilderTest < Minitest::Test
 
   def test_status_embed
     title = 'Timer'
-    status_str = "Current intervals: Pomodoro\n \
-        Status: Pausing\n \
-        Reminder alerts: Off\n \
-        Autoshush: Off"
+    status_str = <<~TEXT
+      Current intervals: Pomodoro
+      Status: Pausing
+      Reminder alerts: Off
+      Autoshush: Off
+    TEXT
     colour = 3_066_993
 
     assert_equal(title, MessageBuilder.status_embed(@session).title)
@@ -40,10 +42,12 @@ class MessageBuilderTest < Minitest::Test
 
   def test_settings_embed
     title = 'Session settings'
-    settings_str = "Pomodoro: 25 min\n \
-        Short break: 5 min\n \
-        Long break: 15 min\n \
-        Interbals: 4"
+    settings_str = <<~TEXT
+      Pomodoro: 25 min
+      Short break: 5 min
+      Long break: 15 min
+      Interbals: 4
+    TEXT
     colour = 16_744_448
 
     assert_equal(title, MessageBuilder.settings_embed(@session).title)
@@ -102,9 +106,11 @@ class MessageBuilderTest < Minitest::Test
 
   def test_reminders_embed
     title = 'Reminder alerts'
-    reminders_str = "Pomodoro: 5 min\n \
-        Short break: 1 min\n \
-        Long break: 5 min"
+    reminders_str = <<~TEXT
+      Pomodoro: 5 min
+      Short break: 1 min
+      Long break: 5 min
+    TEXT
     colour = 16_705_372
 
     assert_equal(title, MessageBuilder.reminders_embed(@session).title)


### PR DESCRIPTION
やったこと
- [x] リファクタリング
  - [x] セッションがCountdownだったときにコマンドを実行しようしないようにしていた処理を#running?メソッドを追加することで一元化した
  - [x] short break→pomodoroにセッションが切り替わるときに再生されるアラートが期待している音楽じゃなかったので適切なアラートが再生されるよう修正
  - [x] embedでDiscordに送信されるメッセージがスマホで見ると表示がくずれていたのでヒアドキュメントに変更することで対応
  - [x] Settings#invalid?のエラーメッセージは3カ所で使われていてドライになっていたので定数化した